### PR TITLE
Save providers when leaving widget

### DIFF
--- a/src/App.mc
+++ b/src/App.mc
@@ -98,6 +98,7 @@ class App extends Application.AppBase {
 
   function onStop(state) {
     log(DEBUG, "App onStop");
+    saveProviders();
   }
 
   function getInitialView() {


### PR DESCRIPTION
This saves the updated counter for counter OTPs.

Before, the counter would just increase but would reset back to zero when the widget was opened again.

The code responsible for updating the counter is https://github.com/ch1bo/garmin-otp-authenticator/blob/f690f695d97a004abaacb33582eb51f4a764c948/src/MainView.mc#L129-L133
which updates the count but never explicitly saves it. This PR makes sure things get saved. I was debating on if it would be better to only call saveProviders when we update the counter in that above code instead of saving on exit.