### PR TITLE
Add support for Vivoactive 5

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -66,6 +66,7 @@
             <iq:product id="vivoactive4"/>
             <iq:product id="vivoactive4s"/>
             <iq:product id="vivoactive_hr"/>
+            <iq:product id="vivoactive5"/>
         </iq:products>
         <iq:permissions/>
         <iq:languages>

--- a/test-all.sh
+++ b/test-all.sh
@@ -3,6 +3,7 @@ set -e
 
 DEVICES=(
   vivoactive3
+  vivoactive5
   vivoactive_hr
   fenix5
   fenix6


### PR DESCRIPTION
Build successfully and currently testing on my watch. No issues encountered so far (even integrates well with the Glances so the token is literally just one swipe away). Only issue encountered was a warning regarding the icon size:
```
WARNING: vivoactive5: The launcher icon (80x80) isn't compatible with the specified launcher icon size of the device 'vivoactive5' (70x70). Image will be scaled to the target size.
```
But since it's scaling down automatically (which is exactly what I'd do manually) I think it's fine.

Close #31 