### PR TITLE
Add support for Forerunner 165 (Music)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.9.0 - UNRELEASED
+
+ - Add support for Forerunner 165 (with Music variant).
+
 ## 1.8.0 - 2024-09-05
 
  - Add support for Fenix 8 (all variants).

--- a/manifest.xml
+++ b/manifest.xml
@@ -31,6 +31,8 @@
             <iq:product id="fenix847mm"/>
             <iq:product id="fenix8solar47mm"/>
             <iq:product id="fenix8solar51mm"/>
+            <iq:product id="fr165"/>
+            <iq:product id="fr165m"/>
             <iq:product id="fr245"/>
             <iq:product id="fr245m"/>
             <iq:product id="fr255"/>

--- a/src/App.mc
+++ b/src/App.mc
@@ -5,6 +5,7 @@ import Toybox.WatchUi;
 
 var _providers as Array<Provider> = [];
 var _currentIndex = 0;
+var _IsShowingCode = false;
 
 (:glance)
 function currentProvider() as Provider? {

--- a/src/MainView.mc
+++ b/src/MainView.mc
@@ -222,6 +222,15 @@ class MainViewDelegate extends WatchUi.BehaviorDelegate {
     if (_providers.size() == 0) {
       var view = new TextInput.TextInputView("Enter name", Alphabet.ALPHANUM);
       WatchUi.pushView(view, new NameInputDelegate(view), WatchUi.SLIDE_RIGHT);
+    } else if (_IsShowingCode) {
+      log(DEBUG, "Enter pressed");
+      var provider = currentProvider();
+      switch (provider) {
+      case instanceof CounterBasedProvider:
+        (provider as CounterBasedProvider).next();
+        WatchUi.requestUpdate();
+        return true;
+      }
     } else {
       var menu = new Menu.MenuView({ :title => "OTP Authenticator" });
       menu.addMenuItem(new Menu.MenuItem("Select entry", null, :select_entry, null));
@@ -233,6 +242,22 @@ class MainViewDelegate extends WatchUi.BehaviorDelegate {
       WatchUi.pushView(menu, new MainMenuDelegate(), WatchUi.SLIDE_LEFT);
     }
     return true;
+  }
+
+  function onBack() {
+    if (_IsShowingCode) {
+      _IsShowingCode = false;
+      var menu = new Menu.MenuView({ :title => "OTP Authenticator" });
+      menu.addMenuItem(new Menu.MenuItem("Select entry", null, :select_entry, null));
+      menu.addMenuItem(new Menu.MenuItem("New entry", null, :new_entry, null));
+      menu.addMenuItem(new Menu.MenuItem("Delete entry", null, :delete_entry, null));
+      menu.addMenuItem(new Menu.MenuItem("Delete all entries", null, :delete_all, null));
+      menu.addMenuItem(new Menu.MenuItem("Export", "to settings", :export_providers, null));
+      menu.addMenuItem(new Menu.MenuItem("Import", "from settings", :import_providers, null));
+      WatchUi.pushView(menu, new MainMenuDelegate(), WatchUi.SLIDE_LEFT);
+      return true;
+    }
+    return false;
   }
 }
 
@@ -280,6 +305,7 @@ class SelectMenuDelegate extends Menu.MenuDelegate {
 
   function onMenuItem(identifier) {
     _currentIndex = identifier;
+    _IsShowingCode = true;
     logf(DEBUG, "setting current index $1$", [_currentIndex]);
     saveProviders();
   }


### PR DESCRIPTION
Adds support for the Forerunner 165 including the Music variant. 

Tests and simulator seem to work fine with the time-based entries, there's just warning about the icon being scaled down.

However, these models don't react on the `ENTER` button for counter-based entries. Do you have an idea/hint where I should look at? The Forerunner 965 has the same issue. 

I found out that pressing the `Start/Stop` aka `Enter` button calls `onHide` instead of `onKey`.

The [docs](https://developer.garmin.com/connect-iq/reference-guides/devices-reference/#forerunner%C2%AE165) also say that these two models should have a enter key.